### PR TITLE
Adjust vault position and remove door closing animation

### DIFF
--- a/client/components/ip-vault/StoryAnimation.tsx
+++ b/client/components/ip-vault/StoryAnimation.tsx
@@ -1321,7 +1321,7 @@ export default function StoryAnimation({
         {/* Vault */}
         <div
           ref={vaultRef}
-          className="absolute left-1/2 top-1/2 h-36 w-52 -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-transparent text-black shadow-[0_0_0_1px_rgba(0,0,0,0.2)] overflow-hidden"
+          className="absolute left-1/2 top-[54%] h-36 w-52 -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-transparent text-black shadow-[0_0_0_1px_rgba(0,0,0,0.2)] overflow-hidden"
         >
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2F75857544e65a4f6982333406121c72a7%2Fa9f23897196141cda50bf40c9cf505c4?format=webp&width=800"

--- a/client/components/ip-vault/StoryAnimation.tsx
+++ b/client/components/ip-vault/StoryAnimation.tsx
@@ -494,7 +494,7 @@ export default function StoryAnimation({
         .to({}, { duration: 0.6 })
         .call(() => audioRef.current?.playWhoosh())
         .to(doorRef.current, { width: "0%", duration: 0.36 })
-        .call(performDeliver)
+        .call(performDeliver);
     } else {
       tl.to(buyerRef.current, {
         left: positions.tee,
@@ -527,7 +527,7 @@ export default function StoryAnimation({
         .to({}, { duration: 0.6 })
         .call(() => audioRef.current?.playWhoosh())
         .to(doorRef.current, { width: "0%", duration: 0.36 })
-        .call(performDeliver)
+        .call(performDeliver);
     }
     return tl;
   }

--- a/client/components/ip-vault/StoryAnimation.tsx
+++ b/client/components/ip-vault/StoryAnimation.tsx
@@ -495,7 +495,6 @@ export default function StoryAnimation({
         .call(() => audioRef.current?.playWhoosh())
         .to(doorRef.current, { width: "0%", duration: 0.36 })
         .call(performDeliver)
-        .to(doorRef.current, { width: "100%", duration: 0.36 });
     } else {
       tl.to(buyerRef.current, {
         left: positions.tee,
@@ -529,7 +528,6 @@ export default function StoryAnimation({
         .call(() => audioRef.current?.playWhoosh())
         .to(doorRef.current, { width: "0%", duration: 0.36 })
         .call(performDeliver)
-        .to(doorRef.current, { width: "100%", duration: 0.36 });
     }
     return tl;
   }

--- a/client/components/ip-vault/StoryAnimation.tsx
+++ b/client/components/ip-vault/StoryAnimation.tsx
@@ -1321,7 +1321,7 @@ export default function StoryAnimation({
         {/* Vault */}
         <div
           ref={vaultRef}
-          className="absolute left-1/2 top-[54%] h-36 w-52 -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-transparent text-black shadow-[0_0_0_1px_rgba(0,0,0,0.2)] overflow-hidden"
+          className="absolute left-1/2 top-[52%] h-36 w-52 -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-transparent text-black shadow-[0_0_0_1px_rgba(0,0,0,0.2)] overflow-hidden"
         >
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2F75857544e65a4f6982333406121c72a7%2Fa9f23897196141cda50bf40c9cf505c4?format=webp&width=800"


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses vault positioning concerns and animation behavior. Users requested the vault position to be moved slightly lower but not too much, questioned the color transition effects, and indicated the vault door should remain open after delivery operations.

## Code changes
- **Vault positioning**: Adjusted vault position from `top-1/2` to `top-[52%]` to move it slightly lower on screen
- **Animation simplification**: Removed door closing animation by eliminating the final `.to(doorRef.current, { width: "100%", duration: 0.36 })` calls in both animation sequences
- **Delivery flow**: Door now stays open after `performDeliver` is called, improving user experienceTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4e3fb5cf91d748b09febeeab282741d7/flare-realm)

👀 [Preview Link](https://4e3fb5cf91d748b09febeeab282741d7-flare-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4e3fb5cf91d748b09febeeab282741d7</projectId>-->
<!--<branchName>flare-realm</branchName>-->