### PR TITLE
Add keyboard shortcuts F and G for vault and TEE playback

### DIFF
--- a/client/components/ip-vault/TabbedFlow.tsx
+++ b/client/components/ip-vault/TabbedFlow.tsx
@@ -28,7 +28,13 @@ export default function TabbedFlow() {
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase();
-      if (tag === "input" || tag === "textarea" || tag === "select" || (e as any).isComposing) return;
+      if (
+        tag === "input" ||
+        tag === "textarea" ||
+        tag === "select" ||
+        (e as any).isComposing
+      )
+        return;
       if (e.repeat) return;
       if (e.key === "f" || e.key === "F") {
         e.preventDefault();

--- a/client/components/ip-vault/TabbedFlow.tsx
+++ b/client/components/ip-vault/TabbedFlow.tsx
@@ -24,6 +24,26 @@ export default function TabbedFlow() {
     };
   }, [type]);
 
+  // Keyboard shortcuts: 'f' plays Vault, 'g' plays TEE
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase();
+      if (tag === "input" || tag === "textarea" || tag === "select" || (e as any).isComposing) return;
+      if (e.repeat) return;
+      if (e.key === "f" || e.key === "F") {
+        e.preventDefault();
+        setType("vault");
+        setPlaySignal(String(Date.now()));
+      } else if (e.key === "g" || e.key === "G") {
+        e.preventDefault();
+        setType("tee");
+        setPlaySignal(String(Date.now()));
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   return (
     <section className="bg-black text-white flex flex-col items-center justify-center min-h-screen p-8 space-y-8 rounded-2xl">
       <h1 className="text-3xl font-bold text-center">IP Vault Flow</h1>


### PR DESCRIPTION
## Purpose
The user requested keyboard shortcuts to enable quick playback control: pressing 'F' should play the non-TEE (vault) content, and pressing 'G' should play the TEE content.

## Code changes
- Added keyboard event listener in `TabbedFlow.tsx` component
- Implemented 'F' key shortcut to switch to vault type and trigger playback
- Implemented 'G' key shortcut to switch to TEE type and trigger playback
- Added input field detection to prevent shortcuts from interfering with text input
- Included repeat key prevention and case-insensitive key handling
- Proper cleanup of event listeners on component unmountTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ab9595401d2d4065a27b353318956b5f/curry-hub)

👀 [Preview Link](https://ab9595401d2d4065a27b353318956b5f-curry-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ab9595401d2d4065a27b353318956b5f</projectId>-->
<!--<branchName>curry-hub</branchName>-->